### PR TITLE
Fixing issue with multigz encodings

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -47,7 +47,7 @@ use std::path::Path;
 
 use crate::{FgError, Result};
 use csv::{QuoteStyle, ReaderBuilder, WriterBuilder};
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use serde::{de::DeserializeOwned, Serialize};
@@ -94,7 +94,7 @@ impl Io {
     {
         let file = File::open(p).map_err(FgError::IoError)?;
         let read: Box<dyn Read> =
-            if Io::is_gzip_path(p) { Box::new(GzDecoder::new(file)) } else { Box::new(file) };
+            if Io::is_gzip_path(p) { Box::new(MultiGzDecoder::new(file)) } else { Box::new(file) };
 
         Ok(BufReader::new(read))
     }


### PR DESCRIPTION
As it turns out `gzip` files with multiple gzip blocks (e.g. bgzipped files) the current choice of flate2 decoding will only decode the first block as currently written in fgoxide.
Switching to `MultiGzDecoder` fixes this and will allow this to work on large bgzipped files.

See documentation below:
https://docs.rs/flate2/latest/flate2/read/struct.GzDecoder.html
https://docs.rs/flate2/latest/flate2/read/struct.MultiGzDecoder.html