### PR TITLE
Fix incompatibility between dependency versions and toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/fgoxide"
 readme = "README.md"
 categories = ["rust-patterns"]
 keywords = ["utilities"]
+rust-version = "1.58.1"
 
 [dependencies]
 thiserror = "^1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.58.1"
+channel = "stable"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
When `channel` is set in to a specific version `rust-toolchain.toml` it fixes that as the version. Typically, what you want to do instead is specify a minimum rust version, which is done using the `rust-version` parameter in Cargo.toml. The alternative is that you have to fix your dependencies at specific versions that you know are compatible with your rust version (e.g. `tempfile = "=3.2.0"`.