### PR TITLE
Add `DelimFile` `new_reader` and `new_writer` methods

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -47,7 +47,9 @@ use std::marker::PhantomData;
 use std::path::Path;
 
 use crate::{FgError, Result};
-use csv::{DeserializeRecordsIntoIter, QuoteStyle, ReaderBuilder, Writer, WriterBuilder, StringRecord};
+use csv::{
+    DeserializeRecordsIntoIter, QuoteStyle, ReaderBuilder, StringRecord, Writer, WriterBuilder,
+};
 use flate2::bufread::MultiGzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -47,7 +47,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 
 use crate::{FgError, Result};
-use csv::{QuoteStyle, ReaderBuilder, DeserializeRecordsIntoIter, WriterBuilder, Writer};
+use csv::{DeserializeRecordsIntoIter, QuoteStyle, ReaderBuilder, Writer, WriterBuilder};
 use flate2::bufread::MultiGzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;


### PR DESCRIPTION
Implements #13 - `new_reader` returns a `DelimFileReader` instance and `new_writer` returns a `DelimFileWriter` instance.

`DelimFileReader` has a `read` method for reading one record at at time. It also implements `Iterator`, and `read` is really just an alias for `next`.

`DelimFileWriter` has a `write` method for writing one record at a time, and a `write_all` method for writing all records from an iterator.

`DelimFile`'s convenience functions are re-written in terms of the new structs.