### PR TITLE
Update to Rust 2024 edition, bump deps, modernize CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,79 +10,59 @@ jobs:
     name: Check
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          profile: minimal
           toolchain: stable
-          override: false
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: check
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - run: cargo check --all-targets
 
   lints:
     name: Lints
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          profile: minimal
           toolchain: stable
-          override: false
           components: rustfmt, clippy
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
-
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - name: Run cargo fmt
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: fmt
-          args: --all -- --check
-
+        run: cargo fmt --all -- --check
       - name: Run cargo clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
-      - name: Run cargo clippy on tests
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: clippy
-          args: --tests -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-24.04, macos-15]
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          profile: minimal
           toolchain: stable
-          override: false
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - run: cargo test --verbose
 
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
-
-      - name: Run tests
-        run: cargo test --verbose
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      # Read rust-version from Cargo.toml so the MSRV check stays in sync
+      # automatically when MSRV is bumped. RUSTUP_TOOLCHAIN overrides the
+      # channel pinned in rust-toolchain.toml so this job actually runs
+      # against the MSRV instead of stable.
+      - name: Read MSRV from Cargo.toml
+        run: |
+          MSRV=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [[ -z "$MSRV" ]]; then echo "Failed to parse rust-version" >&2; exit 1; fi
+          echo "MSRV=$MSRV" >> "$GITHUB_ENV"
+          echo "RUSTUP_TOOLCHAIN=$MSRV" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: ${{ env.MSRV }}
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - run: cargo check --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fgoxide"
-version = "0.6.1-rc.1"
+version = "0.7.0"
 edition = "2024"
 authors = [
     "Tim Fennell <tim@fulcrumgenomics.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fgoxide"
 version = "0.6.1-rc.1"
-edition = "2021"
+edition = "2024"
 authors = [
     "Tim Fennell <tim@fulcrumgenomics.com>",
     "Nils Homer <nils@fulcrumgenomics.com>"
@@ -13,19 +13,19 @@ documentation = "https://docs.rs/fgoxide"
 readme = "README.md"
 categories = ["rust-patterns"]
 keywords = ["utilities"]
-rust-version = "1.58.1"
+rust-version = "1.85"
 
 [dependencies]
-thiserror = "^1"
+thiserror = "^2"
 
 # For auto-gzip handing of files
 flate2 = "^1"
 
 # For auto-serialization of structs to csv/tsv
-csv = "^1, <1.2"
+csv = "^1"
 serde = { version = "^1.0.123", features = ["derive"] }
 serde-aux = "^4"
 
 [dev-dependencies]
-tempfile = "3.2.0"
-rstest = "0.12.0"
+tempfile = "^3"
+rstest = "^0.26"

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -51,10 +51,10 @@ use crate::{FgError, Result};
 use csv::{
     DeserializeRecordsIntoIter, QuoteStyle, ReaderBuilder, StringRecord, Writer, WriterBuilder,
 };
+use flate2::Compression;
 use flate2::bufread::MultiGzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// The set of file extensions to treat as GZIPPED
 const GZIP_EXTENSIONS: [&str; 2] = ["gz", "bgz"];

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
-use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
-use std::sync::mpsc::{sync_channel, Receiver};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::sync::mpsc::{Receiver, sync_channel};
 use std::thread::{self, JoinHandle};
 use std::vec::IntoIter;
 


### PR DESCRIPTION
## Summary
- Migrate to Rust 2024 edition; bump MSRV to 1.85
- Update dependencies: `thiserror` 1 -> 2, `rstest` 0.12 -> 0.26, drop the obsolete `csv = "<1.2"` upper bound (it was there because csv 1.3 required rustc 1.61, no longer relevant), broaden `tempfile` pin to `^3`
- Modernize CI: replace unmaintained `actions-rs/*` actions with `dtolnay/rust-toolchain`; bump `actions/checkout` to v5.0.1 and `Swatinem/rust-cache` to v2.9.1; pin OS images to `ubuntu-24.04`/`macos-15`; collapse two clippy steps into a single `cargo clippy --all-targets`
- Add an MSRV CI job that reads `rust-version` from `Cargo.toml` (so the workflow stays in sync automatically when MSRV is bumped) and runs `cargo check`
- Bump version to 0.7.0

## Test plan
- [ ] CI green on the new workflow (check, lints, test on ubuntu+macos, msrv)
- [ ] `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` all clean locally (verified)
- [ ] `RUSTUP_TOOLCHAIN=1.85 cargo check --all-targets` passes locally (verified)