### PR TITLE
feat(sam): add Template and TemplateIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,14 @@ serde = { version = "^1.0.123", features = ["derive"] }
 serde-aux = "^4"
 
 # For SAM/BAM alignment record types used by the `sam` module.
-noodles-sam = "^0.84"
+noodles-sam = { version = "^0.84", optional = true }
 
 # Byte-string types matching what noodles surfaces for read names.
-bstr = "^1"
+bstr = { version = "^1", optional = true }
+
+[features]
+default = ["sam"]
+sam = ["dep:noodles-sam", "dep:bstr"]
 
 [dev-dependencies]
 tempfile = "^3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ serde-aux = "^4"
 # For SAM/BAM alignment record types used by the `sam` module.
 noodles-sam = "^0.84"
 
+# Byte-string types matching what noodles surfaces for read names.
+bstr = "^1"
+
 [dev-dependencies]
 tempfile = "^3"
 rstest = "^0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ csv = "^1"
 serde = { version = "^1.0.123", features = ["derive"] }
 serde-aux = "^4"
 
+# For SAM/BAM alignment record types used by the `sam` module.
+noodles-sam = "^0.84"
+
 [dev-dependencies]
 tempfile = "^3"
 rstest = "^0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@ pub enum FgError {
     DelimFileHeaderError { expected: String, found: String },
 
     #[error("Records for the same template have different query names: {first} vs {second}.")]
-    InconsistentTemplateNames { first: String, second: String },
+    InconsistentTemplateNames { first: bstr::BString, second: bstr::BString },
 
     #[error("Multiple non-secondary, non-supplementary {read} records for template {name}.")]
-    MultiplePrimaryAlignments { name: String, read: &'static str },
+    MultiplePrimaryAlignments { name: bstr::BString, read: &'static str },
 
     #[error("Cannot construct a Template with no records.")]
     EmptyTemplate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod io;
 pub mod iter;
+#[cfg(feature = "sam")]
 pub mod sam;
 
 use thiserror::Error;
@@ -21,15 +22,19 @@ pub enum FgError {
     #[error("Error parsing delimited data file header.")]
     DelimFileHeaderError { expected: String, found: String },
 
+    #[cfg(feature = "sam")]
     #[error("Records for the same template have different query names: {first} vs {second}.")]
     InconsistentTemplateNames { first: bstr::BString, second: bstr::BString },
 
+    #[cfg(feature = "sam")]
     #[error("Multiple non-secondary, non-supplementary {read} records for template {name}.")]
     MultiplePrimaryAlignments { name: bstr::BString, read: &'static str },
 
+    #[cfg(feature = "sam")]
     #[error("Cannot construct a Template with no records.")]
     EmptyTemplate,
 
+    #[cfg(feature = "sam")]
     #[error("Alignment record is missing a query name.")]
     MissingQueryName,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub enum FgError {
 
     #[cfg(feature = "sam")]
     #[error("Multiple non-secondary, non-supplementary {read} records for template {name}.")]
-    MultiplePrimaryAlignments { name: bstr::BString, read: &'static str },
+    MultiplePrimaryAlignments { name: bstr::BString, read: WhichRead },
 
     #[cfg(feature = "sam")]
     #[error("Cannot construct a Template with no records.")]
@@ -41,3 +41,21 @@ pub enum FgError {
 
 /// Result type that should be used everywhere
 type Result<A> = std::result::Result<A, FgError>;
+
+/// Identifies which end of a paired-read template a record belongs to.
+#[cfg(feature = "sam")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WhichRead {
+    R1,
+    R2,
+}
+
+#[cfg(feature = "sam")]
+impl std::fmt::Display for WhichRead {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WhichRead::R1 => f.write_str("R1"),
+            WhichRead::R2 => f.write_str("R2"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod io;
 pub mod iter;
+pub mod sam;
 
 use thiserror::Error;
 
@@ -19,6 +20,18 @@ pub enum FgError {
 
     #[error("Error parsing delimited data file header.")]
     DelimFileHeaderError { expected: String, found: String },
+
+    #[error("Records for the same template have different query names: {first} vs {second}.")]
+    InconsistentTemplateNames { first: String, second: String },
+
+    #[error("Multiple non-secondary, non-supplementary {read} records for template {name}.")]
+    MultiplePrimaryAlignments { name: String, read: &'static str },
+
+    #[error("Cannot construct a Template with no records.")]
+    EmptyTemplate,
+
+    #[error("Alignment record is missing a query name.")]
+    MissingQueryName,
 }
 
 /// Result type that should be used everywhere

--- a/src/sam/mod.rs
+++ b/src/sam/mod.rs
@@ -1,0 +1,21 @@
+//! Helpers for working with SAM/BAM alignment records.
+//!
+//! This module provides the [`Template`] struct and the [`TemplateIterator`] adapter,
+//! which group alignment records by query name in the same way as the equivalent
+//! abstractions in [`fgbio`] and [`fgpyo`].
+//!
+//! A [`Template`] holds the primary R1 and R2 alignments for a single template along
+//! with its secondary and supplementary alignments. A [`TemplateIterator`] consumes a
+//! queryname-grouped stream of records and yields one [`Template`] per group.
+//!
+//! Records are owned by the resulting [`Template`]; the iterator therefore takes ownership
+//! of records as it consumes them. Records are typed as [`noodles_sam::alignment::RecordBuf`]
+//! so that this module is independent of the source format (SAM, BAM, or otherwise) provided
+//! the input has been deserialized into the buffered alignment record type.
+//!
+//! [`fgbio`]: https://github.com/fulcrumgenomics/fgbio
+//! [`fgpyo`]: https://github.com/fulcrumgenomics/fgpyo
+
+pub mod template;
+
+pub use self::template::{Template, TemplateIterator};

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -17,7 +17,7 @@ use bstr::BString;
 use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record::Flags;
 
-use crate::{FgError, Result};
+use crate::{FgError, Result, WhichRead};
 
 /// All alignment records that share a query name (i.e. belong to the same template).
 ///
@@ -134,7 +134,7 @@ impl Template {
             if self.r1.is_some() {
                 return Err(FgError::MultiplePrimaryAlignments {
                     name: self.name.clone(),
-                    read: "R1",
+                    read: WhichRead::R1,
                 });
             }
             self.r1 = Some(rec);
@@ -142,7 +142,7 @@ impl Template {
             if self.r2.is_some() {
                 return Err(FgError::MultiplePrimaryAlignments {
                     name: self.name.clone(),
-                    read: "R2",
+                    read: WhichRead::R2,
                 });
             }
             self.r2 = Some(rec);
@@ -225,7 +225,15 @@ where
             None => return Some(Err(FgError::MissingQueryName)),
         };
 
-        let mut template = Template { name: name.clone(), ..Template::default() };
+        let mut template = Template {
+            name: name.clone(),
+            r1: None,
+            r2: None,
+            r1_supplementary: Vec::new(),
+            r2_supplementary: Vec::new(),
+            r1_secondary: Vec::new(),
+            r2_secondary: Vec::new(),
+        };
         if let Err(e) = template.add_record(first) {
             return Some(Err(e));
         }
@@ -358,7 +366,7 @@ mod tests {
     #[test]
     fn multiple_primaries_error() {
         let err = Template::from_records(vec![r1_primary("q1"), r1_primary("q1")]).unwrap_err();
-        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read: "R1", .. }));
+        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read: WhichRead::R1, .. }));
     }
 
     #[test]

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -425,6 +425,41 @@ mod tests {
         assert_eq!(t.name, b"q2");
     }
 
+    // Regression: when an underlying error follows a fully accumulated template, the
+    // completed template must be yielded before the error surfaces.  Currently fails:
+    // peek_name returns None for a peeked Err, the loop's None arm consumes the error
+    // immediately, and the in-progress template is dropped on the floor.
+    #[test]
+    fn iterator_yields_completed_template_before_error() {
+        let items: Vec<std::io::Result<RecordBuf>> = vec![
+            Ok(r1_primary("q1")),
+            Ok(r2_primary("q1")),
+            Err(std::io::Error::other("boom")),
+        ];
+        let mut it = TemplateIterator::new(items.into_iter());
+        let t = it.next().unwrap().expect("template q1 should be yielded before the error");
+        assert_eq!(t.name, b"q1");
+        assert_eq!(t.len(), 2);
+        let err = it.next().unwrap().unwrap_err();
+        assert!(matches!(err, FgError::IoError(_)));
+    }
+
+    // Regression: a nameless record encountered after a fully accumulated template should
+    // surface as MissingQueryName *after* the template is yielded, not in place of it.
+    // Currently fails for the same reason as above.
+    #[test]
+    fn iterator_yields_completed_template_before_missing_name_error() {
+        let no_name =
+            RecordBuf::builder().set_flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT).build();
+        let items: Vec<std::io::Result<RecordBuf>> =
+            vec![Ok(r1_primary("q1")), Ok(r2_primary("q1")), Ok(no_name)];
+        let mut it = TemplateIterator::new(items.into_iter());
+        let t = it.next().unwrap().expect("template q1 should be yielded before the error");
+        assert_eq!(t.name, b"q1");
+        let err = it.next().unwrap().unwrap_err();
+        assert!(matches!(err, FgError::MissingQueryName));
+    }
+
     #[test]
     fn iterator_does_not_collapse_repeated_names_across_groups() {
         // If the input is mis-grouped, each contiguous run with the same name becomes a

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -164,6 +164,9 @@ where
     FgError: From<E>,
 {
     inner: std::iter::Peekable<I>,
+    /// An error discovered while peeking the next group's first record. Held back so the
+    /// in-progress template is yielded first; surfaced on the following call to `next`.
+    pending_err: Option<FgError>,
 }
 
 impl<I, E> TemplateIterator<I, E>
@@ -173,15 +176,28 @@ where
 {
     /// Wraps an iterator of records, assumed to be queryname-grouped.
     pub fn new(inner: I) -> Self {
-        Self { inner: inner.peekable() }
+        Self { inner: inner.peekable(), pending_err: None }
     }
 
-    /// Returns a reference to the wrapped iterator's next record without consuming it.
+    /// Peeks the next record's query name. Returns `Some(Ok(name))` if the peek yielded a
+    /// named record, `Some(Err(_))` if the peeked record was an error or had no name (in
+    /// which case the offending record is also consumed so it is not seen twice), or `None`
+    /// if the underlying iterator is exhausted.
     fn peek_name(&mut self) -> Option<Result<Vec<u8>>> {
         match self.inner.peek()? {
-            Ok(rec) => Some(rec.name().map(|n| n.to_vec()).ok_or(FgError::MissingQueryName)),
-            // Cannot move the error out of the peeked Result; pop it on the next call to next().
-            Err(_) => None,
+            Ok(rec) => match rec.name() {
+                Some(n) => Some(Ok(n.to_vec())),
+                None => {
+                    // Drop the bad record so a later call doesn't see it again.
+                    let _ = self.inner.next();
+                    Some(Err(FgError::MissingQueryName))
+                }
+            },
+            // Cannot move the error out of the peeked Result; consume it now.
+            Err(_) => match self.inner.next() {
+                Some(Err(e)) => Some(Err(FgError::from(e))),
+                _ => unreachable!("peek returned Some(Err); next must yield the same Err"),
+            },
         }
     }
 }
@@ -194,6 +210,10 @@ where
     type Item = Result<Template>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(e) = self.pending_err.take() {
+            return Some(Err(e));
+        }
+
         // Pull the first record of the next template, surfacing any underlying error.
         let first = match self.inner.next()? {
             Ok(rec) => rec,
@@ -210,7 +230,8 @@ where
             return Some(Err(e));
         }
 
-        // Peek subsequent records; consume those that share the same query name.
+        // Peek subsequent records; consume those that share the same query name. Errors
+        // discovered during peek are buffered so the completed template is yielded first.
         loop {
             match self.peek_name() {
                 Some(Ok(next_name)) if next_name == name => {
@@ -224,14 +245,11 @@ where
                     }
                 }
                 Some(Ok(_)) => break,
-                Some(Err(e)) => return Some(Err(e)),
-                None => {
-                    // Either the stream is exhausted, or the next item is an error we deferred.
-                    if let Some(Err(e)) = self.inner.next() {
-                        return Some(Err(FgError::from(e)));
-                    }
+                Some(Err(e)) => {
+                    self.pending_err = Some(e);
                     break;
                 }
+                None => break,
             }
         }
 
@@ -414,11 +432,13 @@ mod tests {
 
     #[test]
     fn iterator_propagates_error_mid_template() {
-        // An error encountered partway through a queryname group surfaces as the next
-        // yielded item, abandoning the in-progress template.
+        // An error encountered partway through a queryname group surfaces *after* the
+        // in-progress template is yielded; iteration then resumes with the next group.
         let items: Vec<std::io::Result<RecordBuf>> =
             vec![Ok(r1_primary("q1")), Err(std::io::Error::other("boom")), Ok(r2_primary("q2"))];
         let mut it = TemplateIterator::new(items.into_iter());
+        let t = it.next().unwrap().unwrap();
+        assert_eq!(t.name, b"q1");
         let err = it.next().unwrap().unwrap_err();
         assert!(matches!(err, FgError::IoError(_)));
         let t = it.next().unwrap().unwrap();

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -370,6 +370,36 @@ mod tests {
     }
 
     #[test]
+    fn multiple_r2_primaries_error() {
+        let err = Template::from_records(vec![r2_primary("q1"), r2_primary("q1")]).unwrap_err();
+        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read: WhichRead::R2, .. }));
+    }
+
+    #[test]
+    fn supplementary_only_template_is_allowed() {
+        // No primary in either slot; the template is just supplementaries. fgbio allows
+        // this and so do we.
+        let t =
+            Template::from_records(vec![r1_supplementary("q1"), r2_supplementary("q1")]).unwrap();
+        assert!(t.r1.is_none());
+        assert!(t.r2.is_none());
+        assert_eq!(t.r1_supplementary.len(), 1);
+        assert_eq!(t.r2_supplementary.len(), 1);
+        assert_eq!(t.len(), 2);
+    }
+
+    #[test]
+    fn segmented_without_first_or_last_classifies_as_r2() {
+        // Per the SAM spec a SEGMENTED record without FIRST_SEGMENT or LAST_SEGMENT is an
+        // "unknown segment". We follow fgbio's `!paired || firstOfPair` check, which puts
+        // such records in the R2 slot. This test pins that behavior.
+        let unknown = rec("q1", Flags::SEGMENTED);
+        let t = Template::from_records(vec![unknown]).unwrap();
+        assert!(t.r1.is_none());
+        assert!(t.r2.is_some());
+    }
+
+    #[test]
     fn missing_name_errors() {
         let no_name =
             RecordBuf::builder().set_flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT).build();

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -13,7 +13,7 @@
 
 use std::io;
 
-use bstr::BString;
+use bstr::{BString, ByteSlice};
 use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record::Flags;
 
@@ -59,14 +59,14 @@ impl Template {
         let mut have_name = false;
 
         for rec in records {
-            let rec_name: BString = rec.name().ok_or(FgError::MissingQueryName)?.into();
+            let rec_name = rec.name().ok_or(FgError::MissingQueryName)?;
             if !have_name {
-                t.name = rec_name;
+                t.name = rec_name.into();
                 have_name = true;
-            } else if t.name != rec_name {
+            } else if rec_name != t.name.as_bstr() {
                 return Err(FgError::InconsistentTemplateNames {
                     first: t.name.clone(),
-                    second: rec_name,
+                    second: rec_name.into(),
                 });
             }
 
@@ -180,27 +180,34 @@ where
         Self { inner: inner.peekable(), pending_err: None }
     }
 
-    /// Peeks the next record's query name. Returns `Some(Ok(name))` if the peek yielded a
-    /// named record, `Some(Err(_))` if the peeked record was an error or had no name (in
-    /// which case the offending record is also consumed so it is not seen twice), or `None`
-    /// if the underlying iterator is exhausted.
-    fn peek_name(&mut self) -> Option<Result<BString>> {
+    /// Classifies the next item without allocating: does it belong to the current group,
+    /// start a new one, or surface an error?  Records that the caller can't recover from
+    /// (no name, or an underlying error) are consumed here so a later call doesn't see them
+    /// again.
+    fn peek_outcome(&mut self, current_name: &BString) -> Option<PeekOutcome> {
         match self.inner.peek()? {
             Ok(rec) => match rec.name() {
-                Some(n) => Some(Ok(n.into())),
+                Some(n) if n == current_name.as_bstr() => Some(PeekOutcome::SameName),
+                Some(_) => Some(PeekOutcome::DifferentName),
                 None => {
-                    // Drop the bad record so a later call doesn't see it again.
                     let _ = self.inner.next();
-                    Some(Err(FgError::MissingQueryName))
+                    Some(PeekOutcome::MissingName)
                 }
             },
-            // Cannot move the error out of the peeked Result; consume it now.
             Err(_) => match self.inner.next() {
-                Some(Err(e)) => Some(Err(e.into())),
+                Some(Err(e)) => Some(PeekOutcome::Err(e.into())),
                 _ => unreachable!("peek returned Some(Err); next must yield the same Err"),
             },
         }
     }
+}
+
+/// Outcome of peeking the next record relative to the in-progress template's name.
+enum PeekOutcome {
+    SameName,
+    DifferentName,
+    MissingName,
+    Err(FgError),
 }
 
 impl<I> Iterator for TemplateIterator<I>
@@ -226,7 +233,7 @@ where
         };
 
         let mut template = Template {
-            name: name.clone(),
+            name,
             r1: None,
             r2: None,
             r1_supplementary: Vec::new(),
@@ -241,8 +248,8 @@ where
         // Peek subsequent records; consume those that share the same query name. Errors
         // discovered during peek are buffered so the completed template is yielded first.
         loop {
-            match self.peek_name() {
-                Some(Ok(next_name)) if next_name == name => {
+            match self.peek_outcome(&template.name) {
+                Some(PeekOutcome::SameName) => {
                     // Safe to unwrap: peek returned Some(Ok), so next() yields Some(Ok).
                     let rec = match self.inner.next().unwrap() {
                         Ok(rec) => rec,
@@ -252,8 +259,12 @@ where
                         return Some(Err(e));
                     }
                 }
-                Some(Ok(_)) => break,
-                Some(Err(e)) => {
+                Some(PeekOutcome::DifferentName) => break,
+                Some(PeekOutcome::MissingName) => {
+                    self.pending_err = Some(FgError::MissingQueryName);
+                    break;
+                }
+                Some(PeekOutcome::Err(e)) => {
                     self.pending_err = Some(e);
                     break;
                 }

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -11,6 +11,8 @@
 //!   `fulcrumgenomics/fgpyo@416f0f64`.
 //! - fgpyo `TemplateIterator`: `fgpyo/sam/__init__.py` lines 1564-1581 at the same commit.
 
+use std::io;
+
 use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record::Flags;
 
@@ -156,12 +158,11 @@ impl Template {
 /// after an intervening different name; mis-grouped input will silently produce multiple
 /// [`Template`]s for the same name.
 ///
-/// The adapter wraps any iterator yielding `Result<RecordBuf, E>` where `E` is convertible to
-/// [`FgError`], so it can be layered directly on top of a `noodles` reader iterator.
-pub struct TemplateIterator<I, E>
+/// The adapter wraps any iterator yielding [`io::Result<RecordBuf>`], matching what `noodles`
+/// readers produce.
+pub struct TemplateIterator<I>
 where
-    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
-    FgError: From<E>,
+    I: Iterator<Item = io::Result<RecordBuf>>,
 {
     inner: std::iter::Peekable<I>,
     /// An error discovered while peeking the next group's first record. Held back so the
@@ -169,10 +170,9 @@ where
     pending_err: Option<FgError>,
 }
 
-impl<I, E> TemplateIterator<I, E>
+impl<I> TemplateIterator<I>
 where
-    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
-    FgError: From<E>,
+    I: Iterator<Item = io::Result<RecordBuf>>,
 {
     /// Wraps an iterator of records, assumed to be queryname-grouped.
     pub fn new(inner: I) -> Self {
@@ -195,17 +195,16 @@ where
             },
             // Cannot move the error out of the peeked Result; consume it now.
             Err(_) => match self.inner.next() {
-                Some(Err(e)) => Some(Err(FgError::from(e))),
+                Some(Err(e)) => Some(Err(e.into())),
                 _ => unreachable!("peek returned Some(Err); next must yield the same Err"),
             },
         }
     }
 }
 
-impl<I, E> Iterator for TemplateIterator<I, E>
+impl<I> Iterator for TemplateIterator<I>
 where
-    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
-    FgError: From<E>,
+    I: Iterator<Item = io::Result<RecordBuf>>,
 {
     type Item = Result<Template>;
 
@@ -217,7 +216,7 @@ where
         // Pull the first record of the next template, surfacing any underlying error.
         let first = match self.inner.next()? {
             Ok(rec) => rec,
-            Err(e) => return Some(Err(FgError::from(e))),
+            Err(e) => return Some(Err(e.into())),
         };
 
         let name = match first.name() {
@@ -238,7 +237,7 @@ where
                     // Safe to unwrap: peek returned Some(Ok), so next() yields Some(Ok).
                     let rec = match self.inner.next().unwrap() {
                         Ok(rec) => rec,
-                        Err(e) => return Some(Err(FgError::from(e))),
+                        Err(e) => return Some(Err(e.into())),
                     };
                     if let Err(e) = template.add_record(rec) {
                         return Some(Err(e));
@@ -254,27 +253,6 @@ where
         }
 
         Some(Ok(template))
-    }
-}
-
-/// Convenience adapter trait, mirroring `IntoChunkedReadAheadIterator` in style.
-pub trait IntoTemplateIterator<E>: Sized
-where
-    FgError: From<E>,
-{
-    /// Wraps an iterator of records into a [`TemplateIterator`].
-    fn into_templates(self) -> TemplateIterator<Self, E>
-    where
-        Self: Iterator<Item = std::result::Result<RecordBuf, E>>;
-}
-
-impl<I, E> IntoTemplateIterator<E> for I
-where
-    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
-    FgError: From<E>,
-{
-    fn into_templates(self) -> TemplateIterator<Self, E> {
-        TemplateIterator::new(self)
     }
 }
 
@@ -401,7 +379,7 @@ mod tests {
             r1_primary("q3"),
         ];
         let templates: Vec<Template> =
-            ok_iter(records).into_templates().collect::<Result<Vec<_>>>().unwrap();
+            TemplateIterator::new(ok_iter(records)).collect::<Result<Vec<_>>>().unwrap();
         assert_eq!(templates.len(), 3);
         assert_eq!(templates[0].name, b"q1");
         assert_eq!(templates[0].len(), 2);
@@ -414,7 +392,7 @@ mod tests {
     #[test]
     fn iterator_on_empty_input_yields_nothing() {
         let templates: Vec<Template> =
-            ok_iter(vec![]).into_templates().collect::<Result<Vec<_>>>().unwrap();
+            TemplateIterator::new(ok_iter(vec![])).collect::<Result<Vec<_>>>().unwrap();
         assert!(templates.is_empty());
     }
 
@@ -486,7 +464,7 @@ mod tests {
         // separate Template. This documents (rather than enforces) the assumption.
         let records = vec![r1_primary("q1"), r1_primary("q2"), r1_primary("q1")];
         let templates: Vec<Template> =
-            ok_iter(records).into_templates().collect::<Result<Vec<_>>>().unwrap();
+            TemplateIterator::new(ok_iter(records)).collect::<Result<Vec<_>>>().unwrap();
         assert_eq!(templates.len(), 3);
     }
 }

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -1,0 +1,428 @@
+//! [`Template`] and [`TemplateIterator`] for grouping alignment records by query name.
+//!
+//! Ports the equivalent abstractions from `fgbio` (Scala) and `fgpyo` (Python).
+
+use noodles_sam::alignment::RecordBuf;
+use noodles_sam::alignment::record::Flags;
+
+use crate::{FgError, Result};
+
+/// All alignment records that share a query name (i.e. belong to the same template).
+///
+/// A template typically contains the primary R1 and R2 alignments and any number of
+/// secondary and supplementary alignments for each end. Unpaired records (those without
+/// the [`Flags::SEGMENTED`] flag set) are classified as R1.
+///
+/// Records that are flagged as both secondary and supplementary are placed in the
+/// secondary list, matching `fgbio`'s behavior.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Template {
+    /// The query name shared by all records in this template.
+    pub name: Vec<u8>,
+    /// The primary R1 alignment, if present.
+    pub r1: Option<RecordBuf>,
+    /// The primary R2 alignment, if present.
+    pub r2: Option<RecordBuf>,
+    /// Supplementary R1 alignments.
+    pub r1_supplementary: Vec<RecordBuf>,
+    /// Supplementary R2 alignments.
+    pub r2_supplementary: Vec<RecordBuf>,
+    /// Secondary R1 alignments.
+    pub r1_secondary: Vec<RecordBuf>,
+    /// Secondary R2 alignments.
+    pub r2_secondary: Vec<RecordBuf>,
+}
+
+impl Template {
+    /// Builds a [`Template`] from an iterable of records that all share the same query name.
+    ///
+    /// Returns an error if the input is empty, if records disagree on query name, if a
+    /// record has no query name, or if multiple records would occupy the primary R1 or R2
+    /// slot.
+    pub fn from_records<I>(records: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = RecordBuf>,
+    {
+        let mut t = Template::default();
+        let mut have_name = false;
+
+        for rec in records {
+            let rec_name = rec.name().ok_or(FgError::MissingQueryName)?.to_vec();
+            if !have_name {
+                t.name = rec_name;
+                have_name = true;
+            } else if t.name != rec_name {
+                return Err(FgError::InconsistentTemplateNames {
+                    first: String::from_utf8_lossy(&t.name).into_owned(),
+                    second: String::from_utf8_lossy(&rec_name).into_owned(),
+                });
+            }
+
+            t.add_record(rec)?;
+        }
+
+        if !have_name { Err(FgError::EmptyTemplate) } else { Ok(t) }
+    }
+
+    /// Returns the total number of records held by this template.
+    pub fn len(&self) -> usize {
+        self.r1.is_some() as usize
+            + self.r2.is_some() as usize
+            + self.r1_supplementary.len()
+            + self.r2_supplementary.len()
+            + self.r1_secondary.len()
+            + self.r2_secondary.len()
+    }
+
+    /// Returns true if this template holds no records.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an iterator over the primary R1 and R2 records.
+    pub fn primary_reads(&self) -> impl Iterator<Item = &RecordBuf> {
+        self.r1.iter().chain(self.r2.iter())
+    }
+
+    /// Returns an iterator over every record held by this template, in the order
+    /// primary, supplementary, secondary, R1 before R2 within each category.
+    pub fn all_reads(&self) -> impl Iterator<Item = &RecordBuf> {
+        self.r1
+            .iter()
+            .chain(self.r2.iter())
+            .chain(self.r1_supplementary.iter())
+            .chain(self.r2_supplementary.iter())
+            .chain(self.r1_secondary.iter())
+            .chain(self.r2_secondary.iter())
+    }
+
+    /// Inserts a single record into the appropriate slot. Assumes the query name has
+    /// already been validated against the rest of the template.
+    fn add_record(&mut self, rec: RecordBuf) -> Result<()> {
+        let flags = rec.flags();
+        // A record is treated as R1 if it is unpaired or explicitly marked as the first
+        // segment. Records without SEGMENTED follow fgbio in landing in the R1 slot.
+        let is_r1 = !flags.contains(Flags::SEGMENTED) || flags.contains(Flags::FIRST_SEGMENT);
+
+        // Order matters: a record marked as both secondary and supplementary is treated
+        // as secondary, matching fgbio.
+        if flags.contains(Flags::SECONDARY) {
+            if is_r1 {
+                self.r1_secondary.push(rec);
+            } else {
+                self.r2_secondary.push(rec);
+            }
+        } else if flags.contains(Flags::SUPPLEMENTARY) {
+            if is_r1 {
+                self.r1_supplementary.push(rec);
+            } else {
+                self.r2_supplementary.push(rec);
+            }
+        } else if is_r1 {
+            if self.r1.is_some() {
+                return Err(FgError::MultiplePrimaryAlignments {
+                    name: String::from_utf8_lossy(&self.name).into_owned(),
+                    read: "R1",
+                });
+            }
+            self.r1 = Some(rec);
+        } else {
+            if self.r2.is_some() {
+                return Err(FgError::MultiplePrimaryAlignments {
+                    name: String::from_utf8_lossy(&self.name).into_owned(),
+                    read: "R2",
+                });
+            }
+            self.r2 = Some(rec);
+        }
+        Ok(())
+    }
+}
+
+/// Adapter that groups a queryname-grouped stream of [`RecordBuf`] values into [`Template`]s.
+///
+/// The underlying iterator must already be queryname-sorted or queryname-grouped: the adapter
+/// terminates a template as soon as it sees a record whose query name differs from the previous
+/// record. It does not detect the case where the same query name reappears later in the stream
+/// after an intervening different name; mis-grouped input will silently produce multiple
+/// [`Template`]s for the same name.
+///
+/// The adapter wraps any iterator yielding `Result<RecordBuf, E>` where `E` is convertible to
+/// [`FgError`], so it can be layered directly on top of a `noodles` reader iterator.
+pub struct TemplateIterator<I, E>
+where
+    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
+    FgError: From<E>,
+{
+    inner: std::iter::Peekable<I>,
+}
+
+impl<I, E> TemplateIterator<I, E>
+where
+    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
+    FgError: From<E>,
+{
+    /// Wraps an iterator of records, assumed to be queryname-grouped.
+    pub fn new(inner: I) -> Self {
+        Self { inner: inner.peekable() }
+    }
+
+    /// Returns a reference to the wrapped iterator's next record without consuming it.
+    fn peek_name(&mut self) -> Option<Result<Vec<u8>>> {
+        match self.inner.peek()? {
+            Ok(rec) => Some(rec.name().map(|n| n.to_vec()).ok_or(FgError::MissingQueryName)),
+            // Cannot move the error out of the peeked Result; pop it on the next call to next().
+            Err(_) => None,
+        }
+    }
+}
+
+impl<I, E> Iterator for TemplateIterator<I, E>
+where
+    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
+    FgError: From<E>,
+{
+    type Item = Result<Template>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Pull the first record of the next template, surfacing any underlying error.
+        let first = match self.inner.next()? {
+            Ok(rec) => rec,
+            Err(e) => return Some(Err(FgError::from(e))),
+        };
+
+        let name = match first.name() {
+            Some(n) => n.to_vec(),
+            None => return Some(Err(FgError::MissingQueryName)),
+        };
+
+        let mut template = Template { name: name.clone(), ..Template::default() };
+        if let Err(e) = template.add_record(first) {
+            return Some(Err(e));
+        }
+
+        // Peek subsequent records; consume those that share the same query name.
+        loop {
+            match self.peek_name() {
+                Some(Ok(next_name)) if next_name == name => {
+                    // Safe to unwrap: peek returned Some(Ok), so next() yields Some(Ok).
+                    let rec = match self.inner.next().unwrap() {
+                        Ok(rec) => rec,
+                        Err(e) => return Some(Err(FgError::from(e))),
+                    };
+                    if let Err(e) = template.add_record(rec) {
+                        return Some(Err(e));
+                    }
+                }
+                Some(Ok(_)) => break,
+                Some(Err(e)) => return Some(Err(e)),
+                None => {
+                    // Either the stream is exhausted, or the next item is an error we deferred.
+                    if let Some(Err(e)) = self.inner.next() {
+                        return Some(Err(FgError::from(e)));
+                    }
+                    break;
+                }
+            }
+        }
+
+        Some(Ok(template))
+    }
+}
+
+/// Convenience adapter trait, mirroring `IntoChunkedReadAheadIterator` in style.
+pub trait IntoTemplateIterator<E>: Sized
+where
+    FgError: From<E>,
+{
+    /// Wraps an iterator of records into a [`TemplateIterator`].
+    fn into_templates(self) -> TemplateIterator<Self, E>
+    where
+        Self: Iterator<Item = std::result::Result<RecordBuf, E>>;
+}
+
+impl<I, E> IntoTemplateIterator<E> for I
+where
+    I: Iterator<Item = std::result::Result<RecordBuf, E>>,
+    FgError: From<E>,
+{
+    fn into_templates(self) -> TemplateIterator<Self, E> {
+        TemplateIterator::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles_sam::alignment::RecordBuf;
+    use noodles_sam::alignment::record::Flags;
+
+    /// Builds a record with the given query name and flags. Other fields are left default.
+    fn rec(name: &str, flags: Flags) -> RecordBuf {
+        RecordBuf::builder().set_name(name.as_bytes()).set_flags(flags).build()
+    }
+
+    /// A read 1, primary alignment.
+    fn r1_primary(name: &str) -> RecordBuf {
+        rec(name, Flags::SEGMENTED | Flags::FIRST_SEGMENT)
+    }
+
+    /// A read 2, primary alignment.
+    fn r2_primary(name: &str) -> RecordBuf {
+        rec(name, Flags::SEGMENTED | Flags::LAST_SEGMENT)
+    }
+
+    fn r1_supplementary(name: &str) -> RecordBuf {
+        rec(name, Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SUPPLEMENTARY)
+    }
+
+    fn r2_supplementary(name: &str) -> RecordBuf {
+        rec(name, Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::SUPPLEMENTARY)
+    }
+
+    fn r1_secondary(name: &str) -> RecordBuf {
+        rec(name, Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SECONDARY)
+    }
+
+    fn r2_secondary(name: &str) -> RecordBuf {
+        rec(name, Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::SECONDARY)
+    }
+
+    fn ok_iter(records: Vec<RecordBuf>) -> impl Iterator<Item = std::io::Result<RecordBuf>> {
+        records.into_iter().map(Ok)
+    }
+
+    #[test]
+    fn paired_primary_only() {
+        let t = Template::from_records(vec![r1_primary("q1"), r2_primary("q1")]).unwrap();
+        assert_eq!(t.name, b"q1");
+        assert!(t.r1.is_some());
+        assert!(t.r2.is_some());
+        assert_eq!(t.len(), 2);
+    }
+
+    #[test]
+    fn paired_with_supplementary_and_secondary() {
+        let records = vec![
+            r1_primary("q1"),
+            r2_primary("q1"),
+            r1_supplementary("q1"),
+            r2_supplementary("q1"),
+            r1_secondary("q1"),
+            r2_secondary("q1"),
+        ];
+        let t = Template::from_records(records).unwrap();
+        assert_eq!(t.r1_supplementary.len(), 1);
+        assert_eq!(t.r2_supplementary.len(), 1);
+        assert_eq!(t.r1_secondary.len(), 1);
+        assert_eq!(t.r2_secondary.len(), 1);
+        assert_eq!(t.len(), 6);
+    }
+
+    #[test]
+    fn unpaired_record_classifies_as_r1() {
+        let t = Template::from_records(vec![rec("q1", Flags::empty())]).unwrap();
+        assert!(t.r1.is_some());
+        assert!(t.r2.is_none());
+    }
+
+    #[test]
+    fn secondary_supplementary_goes_to_secondary() {
+        // Per fgbio, a record marked as both secondary and supplementary is classified as
+        // secondary (the secondary check happens first).
+        let flags =
+            Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SECONDARY | Flags::SUPPLEMENTARY;
+        let t = Template::from_records(vec![r1_primary("q1"), rec("q1", flags)]).unwrap();
+        assert_eq!(t.r1_secondary.len(), 1);
+        assert!(t.r1_supplementary.is_empty());
+    }
+
+    #[test]
+    fn empty_input_errors() {
+        let err = Template::from_records(Vec::<RecordBuf>::new()).unwrap_err();
+        assert!(matches!(err, FgError::EmptyTemplate));
+    }
+
+    #[test]
+    fn inconsistent_names_error() {
+        let err = Template::from_records(vec![r1_primary("q1"), r2_primary("q2")]).unwrap_err();
+        assert!(matches!(err, FgError::InconsistentTemplateNames { .. }));
+    }
+
+    #[test]
+    fn multiple_primaries_error() {
+        let err = Template::from_records(vec![r1_primary("q1"), r1_primary("q1")]).unwrap_err();
+        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read: "R1", .. }));
+    }
+
+    #[test]
+    fn missing_name_errors() {
+        let no_name =
+            RecordBuf::builder().set_flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT).build();
+        let err = Template::from_records(vec![no_name]).unwrap_err();
+        assert!(matches!(err, FgError::MissingQueryName));
+    }
+
+    #[test]
+    fn iterator_yields_one_template_per_group() {
+        let records = vec![
+            r1_primary("q1"),
+            r2_primary("q1"),
+            r1_primary("q2"),
+            r2_primary("q2"),
+            r2_supplementary("q2"),
+            r1_primary("q3"),
+        ];
+        let templates: Vec<Template> =
+            ok_iter(records).into_templates().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(templates.len(), 3);
+        assert_eq!(templates[0].name, b"q1");
+        assert_eq!(templates[0].len(), 2);
+        assert_eq!(templates[1].name, b"q2");
+        assert_eq!(templates[1].len(), 3);
+        assert_eq!(templates[2].name, b"q3");
+        assert_eq!(templates[2].len(), 1);
+    }
+
+    #[test]
+    fn iterator_on_empty_input_yields_nothing() {
+        let templates: Vec<Template> =
+            ok_iter(vec![]).into_templates().collect::<Result<Vec<_>>>().unwrap();
+        assert!(templates.is_empty());
+    }
+
+    #[test]
+    fn iterator_propagates_underlying_errors() {
+        let items: Vec<std::io::Result<RecordBuf>> =
+            vec![Err(std::io::Error::other("boom")), Ok(r1_primary("q1"))];
+        let mut it = TemplateIterator::new(items.into_iter());
+        let err = it.next().unwrap().unwrap_err();
+        assert!(matches!(err, FgError::IoError(_)));
+        // Subsequent records still produce a template.
+        let t = it.next().unwrap().unwrap();
+        assert_eq!(t.name, b"q1");
+    }
+
+    #[test]
+    fn iterator_propagates_error_mid_template() {
+        // An error encountered partway through a queryname group surfaces as the next
+        // yielded item, abandoning the in-progress template.
+        let items: Vec<std::io::Result<RecordBuf>> =
+            vec![Ok(r1_primary("q1")), Err(std::io::Error::other("boom")), Ok(r2_primary("q2"))];
+        let mut it = TemplateIterator::new(items.into_iter());
+        let err = it.next().unwrap().unwrap_err();
+        assert!(matches!(err, FgError::IoError(_)));
+        let t = it.next().unwrap().unwrap();
+        assert_eq!(t.name, b"q2");
+    }
+
+    #[test]
+    fn iterator_does_not_collapse_repeated_names_across_groups() {
+        // If the input is mis-grouped, each contiguous run with the same name becomes a
+        // separate Template. This documents (rather than enforces) the assumption.
+        let records = vec![r1_primary("q1"), r1_primary("q2"), r1_primary("q1")];
+        let templates: Vec<Template> =
+            ok_iter(records).into_templates().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(templates.len(), 3);
+    }
+}

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -270,6 +270,34 @@ mod tests {
     use super::*;
     use noodles_sam::alignment::RecordBuf;
     use noodles_sam::alignment::record::Flags;
+    use rstest::rstest;
+
+    /// Identifies which of the seven `Template` slots a single record landed in.
+    #[derive(Debug, PartialEq)]
+    enum Slot {
+        R1Primary,
+        R2Primary,
+        R1Supp,
+        R2Supp,
+        R1Sec,
+        R2Sec,
+    }
+
+    fn slot_of(t: &Template) -> Slot {
+        if t.r1.is_some() {
+            Slot::R1Primary
+        } else if t.r2.is_some() {
+            Slot::R2Primary
+        } else if !t.r1_supplementary.is_empty() {
+            Slot::R1Supp
+        } else if !t.r2_supplementary.is_empty() {
+            Slot::R2Supp
+        } else if !t.r1_secondary.is_empty() {
+            Slot::R1Sec
+        } else {
+            Slot::R2Sec
+        }
+    }
 
     /// Builds a record with the given query name and flags. Other fields are left default.
     fn rec(name: &str, flags: Flags) -> RecordBuf {
@@ -333,22 +361,61 @@ mod tests {
         assert_eq!(t.len(), 6);
     }
 
-    #[test]
-    fn unpaired_record_classifies_as_r1() {
-        let t = Template::from_records(vec![rec("q1", Flags::empty())]).unwrap();
-        assert!(t.r1.is_some());
-        assert!(t.r2.is_none());
+    /// Single-record classification across the flag-bit space.  Pins fgbio's behavior:
+    /// secondary wins over supplementary, unpaired and unknown-segment records are not
+    /// rejected, and `SEGMENTED` without `FIRST_SEGMENT` or `LAST_SEGMENT` falls through
+    /// to the R2 slot per the `!paired || firstOfPair` rule.
+    #[rstest]
+    #[case::unpaired(Flags::empty(), Slot::R1Primary)]
+    #[case::unpaired_secondary(Flags::SECONDARY, Slot::R1Sec)]
+    #[case::unpaired_supplementary(Flags::SUPPLEMENTARY, Slot::R1Supp)]
+    #[case::r1_primary(Flags::SEGMENTED | Flags::FIRST_SEGMENT, Slot::R1Primary)]
+    #[case::r2_primary(Flags::SEGMENTED | Flags::LAST_SEGMENT, Slot::R2Primary)]
+    #[case::r1_supplementary(
+        Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SUPPLEMENTARY, Slot::R1Supp,
+    )]
+    #[case::r2_supplementary(
+        Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::SUPPLEMENTARY, Slot::R2Supp,
+    )]
+    #[case::r1_secondary(
+        Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SECONDARY, Slot::R1Sec,
+    )]
+    #[case::r2_secondary(
+        Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::SECONDARY, Slot::R2Sec,
+    )]
+    #[case::r1_secondary_supplementary(
+        Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SECONDARY | Flags::SUPPLEMENTARY,
+        Slot::R1Sec,
+    )]
+    #[case::r2_secondary_supplementary(
+        Flags::SEGMENTED | Flags::LAST_SEGMENT | Flags::SECONDARY | Flags::SUPPLEMENTARY,
+        Slot::R2Sec,
+    )]
+    #[case::unknown_segment(Flags::SEGMENTED, Slot::R2Primary)]
+    fn classifies_into_correct_slot(#[case] flags: Flags, #[case] expected: Slot) {
+        let t = Template::from_records(vec![rec("q1", flags)]).unwrap();
+        assert_eq!(slot_of(&t), expected);
     }
 
     #[test]
-    fn secondary_supplementary_goes_to_secondary() {
-        // Per fgbio, a record marked as both secondary and supplementary is classified as
-        // secondary (the secondary check happens first).
-        let flags =
-            Flags::SEGMENTED | Flags::FIRST_SEGMENT | Flags::SECONDARY | Flags::SUPPLEMENTARY;
-        let t = Template::from_records(vec![r1_primary("q1"), rec("q1", flags)]).unwrap();
-        assert_eq!(t.r1_secondary.len(), 1);
-        assert!(t.r1_supplementary.is_empty());
+    fn supplementary_only_template_is_allowed() {
+        // No primary in either slot; fgbio allows this and so do we.
+        let t =
+            Template::from_records(vec![r1_supplementary("q1"), r2_supplementary("q1")]).unwrap();
+        assert_eq!(t.r1_supplementary.len(), 1);
+        assert_eq!(t.r2_supplementary.len(), 1);
+        assert!(t.r1.is_none() && t.r2.is_none());
+    }
+
+    #[rstest]
+    #[case::r1(WhichRead::R1, vec![r1_primary("q1"), r1_primary("q1")])]
+    #[case::r2(WhichRead::R2, vec![r2_primary("q1"), r2_primary("q1")])]
+    fn multiple_primaries_per_end_errors(
+        #[case] expected: WhichRead,
+        #[case] records: Vec<RecordBuf>,
+    ) {
+        let err = Template::from_records(records).unwrap_err();
+        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read, .. } if read == expected));
     }
 
     #[test]
@@ -361,42 +428,6 @@ mod tests {
     fn inconsistent_names_error() {
         let err = Template::from_records(vec![r1_primary("q1"), r2_primary("q2")]).unwrap_err();
         assert!(matches!(err, FgError::InconsistentTemplateNames { .. }));
-    }
-
-    #[test]
-    fn multiple_primaries_error() {
-        let err = Template::from_records(vec![r1_primary("q1"), r1_primary("q1")]).unwrap_err();
-        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read: WhichRead::R1, .. }));
-    }
-
-    #[test]
-    fn multiple_r2_primaries_error() {
-        let err = Template::from_records(vec![r2_primary("q1"), r2_primary("q1")]).unwrap_err();
-        assert!(matches!(err, FgError::MultiplePrimaryAlignments { read: WhichRead::R2, .. }));
-    }
-
-    #[test]
-    fn supplementary_only_template_is_allowed() {
-        // No primary in either slot; the template is just supplementaries. fgbio allows
-        // this and so do we.
-        let t =
-            Template::from_records(vec![r1_supplementary("q1"), r2_supplementary("q1")]).unwrap();
-        assert!(t.r1.is_none());
-        assert!(t.r2.is_none());
-        assert_eq!(t.r1_supplementary.len(), 1);
-        assert_eq!(t.r2_supplementary.len(), 1);
-        assert_eq!(t.len(), 2);
-    }
-
-    #[test]
-    fn segmented_without_first_or_last_classifies_as_r2() {
-        // Per the SAM spec a SEGMENTED record without FIRST_SEGMENT or LAST_SEGMENT is an
-        // "unknown segment". We follow fgbio's `!paired || firstOfPair` check, which puts
-        // such records in the R2 slot. This test pins that behavior.
-        let unknown = rec("q1", Flags::SEGMENTED);
-        let t = Template::from_records(vec![unknown]).unwrap();
-        assert!(t.r1.is_none());
-        assert!(t.r2.is_some());
     }
 
     #[test]
@@ -447,54 +478,33 @@ mod tests {
         assert_eq!(t.name, b"q1");
     }
 
-    #[test]
-    fn iterator_propagates_error_mid_template() {
-        // An error encountered partway through a queryname group surfaces *after* the
-        // in-progress template is yielded; iteration then resumes with the next group.
+    /// A peek-time error must surface *after* any in-progress template is yielded, and
+    /// the iterator must then resume with the next group.  Originally bug #1 dropped the
+    /// in-progress template on the floor; this also covers the missing-name variant of
+    /// the same bug class.
+    #[rstest]
+    #[case::io_error(
+        Err(std::io::Error::other("boom")),
+        FgError::IoError(std::io::Error::other("boom"))
+    )]
+    #[case::missing_name(
+        Ok(RecordBuf::builder().set_flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT).build()),
+        FgError::MissingQueryName,
+    )]
+    fn iterator_yields_completed_template_before_peek_time_error(
+        #[case] bad: std::io::Result<RecordBuf>,
+        #[case] expected_err: FgError,
+    ) {
         let items: Vec<std::io::Result<RecordBuf>> =
-            vec![Ok(r1_primary("q1")), Err(std::io::Error::other("boom")), Ok(r2_primary("q2"))];
+            vec![Ok(r1_primary("q1")), Ok(r2_primary("q1")), bad, Ok(r1_primary("q2"))];
         let mut it = TemplateIterator::new(items.into_iter());
-        let t = it.next().unwrap().unwrap();
-        assert_eq!(t.name, b"q1");
-        let err = it.next().unwrap().unwrap_err();
-        assert!(matches!(err, FgError::IoError(_)));
-        let t = it.next().unwrap().unwrap();
-        assert_eq!(t.name, b"q2");
-    }
-
-    // Regression: when an underlying error follows a fully accumulated template, the
-    // completed template must be yielded before the error surfaces.  Currently fails:
-    // peek_name returns None for a peeked Err, the loop's None arm consumes the error
-    // immediately, and the in-progress template is dropped on the floor.
-    #[test]
-    fn iterator_yields_completed_template_before_error() {
-        let items: Vec<std::io::Result<RecordBuf>> = vec![
-            Ok(r1_primary("q1")),
-            Ok(r2_primary("q1")),
-            Err(std::io::Error::other("boom")),
-        ];
-        let mut it = TemplateIterator::new(items.into_iter());
-        let t = it.next().unwrap().expect("template q1 should be yielded before the error");
+        let t = it.next().unwrap().expect("template q1 yields before the error");
         assert_eq!(t.name, b"q1");
         assert_eq!(t.len(), 2);
         let err = it.next().unwrap().unwrap_err();
-        assert!(matches!(err, FgError::IoError(_)));
-    }
-
-    // Regression: a nameless record encountered after a fully accumulated template should
-    // surface as MissingQueryName *after* the template is yielded, not in place of it.
-    // Currently fails for the same reason as above.
-    #[test]
-    fn iterator_yields_completed_template_before_missing_name_error() {
-        let no_name =
-            RecordBuf::builder().set_flags(Flags::SEGMENTED | Flags::FIRST_SEGMENT).build();
-        let items: Vec<std::io::Result<RecordBuf>> =
-            vec![Ok(r1_primary("q1")), Ok(r2_primary("q1")), Ok(no_name)];
-        let mut it = TemplateIterator::new(items.into_iter());
-        let t = it.next().unwrap().expect("template q1 should be yielded before the error");
-        assert_eq!(t.name, b"q1");
-        let err = it.next().unwrap().unwrap_err();
-        assert!(matches!(err, FgError::MissingQueryName));
+        assert_eq!(std::mem::discriminant(&err), std::mem::discriminant(&expected_err));
+        let t = it.next().unwrap().unwrap();
+        assert_eq!(t.name, b"q2");
     }
 
     #[test]

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -1,6 +1,15 @@
 //! [`Template`] and [`TemplateIterator`] for grouping alignment records by query name.
 //!
-//! Ports the equivalent abstractions from `fgbio` (Scala) and `fgpyo` (Python).
+//! Ports the equivalent abstractions from `fgbio` (Scala) and `fgpyo` (Python). The
+//! source material being ported, pinned to the upstream commits at the time this module
+//! was written:
+//!
+//! - fgbio `Template` (case class + companion object): `Bams.scala` lines 47-178 at
+//!   `fulcrumgenomics/fgbio@768d38c0`.
+//! - fgbio `templateIterator`: `ZipperBams.scala` line 109 at the same commit.
+//! - fgpyo `Template`: `fgpyo/sam/__init__.py` lines 1346-1563 at
+//!   `fulcrumgenomics/fgpyo@416f0f64`.
+//! - fgpyo `TemplateIterator`: `fgpyo/sam/__init__.py` lines 1564-1581 at the same commit.
 
 use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record::Flags;

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -13,6 +13,7 @@
 
 use std::io;
 
+use bstr::BString;
 use noodles_sam::alignment::RecordBuf;
 use noodles_sam::alignment::record::Flags;
 
@@ -29,7 +30,7 @@ use crate::{FgError, Result};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Template {
     /// The query name shared by all records in this template.
-    pub name: Vec<u8>,
+    pub name: BString,
     /// The primary R1 alignment, if present.
     pub r1: Option<RecordBuf>,
     /// The primary R2 alignment, if present.
@@ -58,14 +59,14 @@ impl Template {
         let mut have_name = false;
 
         for rec in records {
-            let rec_name = rec.name().ok_or(FgError::MissingQueryName)?.to_vec();
+            let rec_name: BString = rec.name().ok_or(FgError::MissingQueryName)?.into();
             if !have_name {
                 t.name = rec_name;
                 have_name = true;
             } else if t.name != rec_name {
                 return Err(FgError::InconsistentTemplateNames {
-                    first: String::from_utf8_lossy(&t.name).into_owned(),
-                    second: String::from_utf8_lossy(&rec_name).into_owned(),
+                    first: t.name.clone(),
+                    second: rec_name,
                 });
             }
 
@@ -132,7 +133,7 @@ impl Template {
         } else if is_r1 {
             if self.r1.is_some() {
                 return Err(FgError::MultiplePrimaryAlignments {
-                    name: String::from_utf8_lossy(&self.name).into_owned(),
+                    name: self.name.clone(),
                     read: "R1",
                 });
             }
@@ -140,7 +141,7 @@ impl Template {
         } else {
             if self.r2.is_some() {
                 return Err(FgError::MultiplePrimaryAlignments {
-                    name: String::from_utf8_lossy(&self.name).into_owned(),
+                    name: self.name.clone(),
                     read: "R2",
                 });
             }
@@ -183,10 +184,10 @@ where
     /// named record, `Some(Err(_))` if the peeked record was an error or had no name (in
     /// which case the offending record is also consumed so it is not seen twice), or `None`
     /// if the underlying iterator is exhausted.
-    fn peek_name(&mut self) -> Option<Result<Vec<u8>>> {
+    fn peek_name(&mut self) -> Option<Result<BString>> {
         match self.inner.peek()? {
             Ok(rec) => match rec.name() {
-                Some(n) => Some(Ok(n.to_vec())),
+                Some(n) => Some(Ok(n.into())),
                 None => {
                     // Drop the bad record so a later call doesn't see it again.
                     let _ = self.inner.next();
@@ -219,8 +220,8 @@ where
             Err(e) => return Some(Err(e.into())),
         };
 
-        let name = match first.name() {
-            Some(n) => n.to_vec(),
+        let name: BString = match first.name() {
+            Some(n) => n.into(),
             None => return Some(Err(FgError::MissingQueryName)),
         };
 

--- a/src/sam/template.rs
+++ b/src/sam/template.rs
@@ -166,9 +166,6 @@ where
     I: Iterator<Item = io::Result<RecordBuf>>,
 {
     inner: std::iter::Peekable<I>,
-    /// An error discovered while peeking the next group's first record. Held back so the
-    /// in-progress template is yielded first; surfaced on the following call to `next`.
-    pending_err: Option<FgError>,
 }
 
 impl<I> TemplateIterator<I>
@@ -177,37 +174,8 @@ where
 {
     /// Wraps an iterator of records, assumed to be queryname-grouped.
     pub fn new(inner: I) -> Self {
-        Self { inner: inner.peekable(), pending_err: None }
+        Self { inner: inner.peekable() }
     }
-
-    /// Classifies the next item without allocating: does it belong to the current group,
-    /// start a new one, or surface an error?  Records that the caller can't recover from
-    /// (no name, or an underlying error) are consumed here so a later call doesn't see them
-    /// again.
-    fn peek_outcome(&mut self, current_name: &BString) -> Option<PeekOutcome> {
-        match self.inner.peek()? {
-            Ok(rec) => match rec.name() {
-                Some(n) if n == current_name.as_bstr() => Some(PeekOutcome::SameName),
-                Some(_) => Some(PeekOutcome::DifferentName),
-                None => {
-                    let _ = self.inner.next();
-                    Some(PeekOutcome::MissingName)
-                }
-            },
-            Err(_) => match self.inner.next() {
-                Some(Err(e)) => Some(PeekOutcome::Err(e.into())),
-                _ => unreachable!("peek returned Some(Err); next must yield the same Err"),
-            },
-        }
-    }
-}
-
-/// Outcome of peeking the next record relative to the in-progress template's name.
-enum PeekOutcome {
-    SameName,
-    DifferentName,
-    MissingName,
-    Err(FgError),
 }
 
 impl<I> Iterator for TemplateIterator<I>
@@ -217,11 +185,8 @@ where
     type Item = Result<Template>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(e) = self.pending_err.take() {
-            return Some(Err(e));
-        }
-
-        // Pull the first record of the next template, surfacing any underlying error.
+        // Pull the first record of the next template, surfacing any underlying error
+        // or missing-name error directly.
         let first = match self.inner.next()? {
             Ok(rec) => rec,
             Err(e) => return Some(Err(e.into())),
@@ -245,30 +210,22 @@ where
             return Some(Err(e));
         }
 
-        // Peek subsequent records; consume those that share the same query name. Errors
-        // discovered during peek are buffered so the completed template is yielded first.
-        loop {
-            match self.peek_outcome(&template.name) {
-                Some(PeekOutcome::SameName) => {
-                    // Safe to unwrap: peek returned Some(Ok), so next() yields Some(Ok).
-                    let rec = match self.inner.next().unwrap() {
-                        Ok(rec) => rec,
-                        Err(e) => return Some(Err(e.into())),
+        // Consume records that share the same query name. Any peek-time anomaly
+        // (different name, missing name, underlying Err) is treated as a group
+        // boundary; the next call to `next` will encounter it via the front-of-loop
+        // logic above and surface it as its own item.
+        while let Some(Ok(rec)) = self.inner.peek() {
+            match rec.name() {
+                Some(n) if n == template.name.as_bstr() => {
+                    let rec = match self.inner.next() {
+                        Some(Ok(rec)) => rec,
+                        _ => unreachable!("peek returned Some(Ok); next must yield the same"),
                     };
                     if let Err(e) = template.add_record(rec) {
                         return Some(Err(e));
                     }
                 }
-                Some(PeekOutcome::DifferentName) => break,
-                Some(PeekOutcome::MissingName) => {
-                    self.pending_err = Some(FgError::MissingQueryName);
-                    break;
-                }
-                Some(PeekOutcome::Err(e)) => {
-                    self.pending_err = Some(e);
-                    break;
-                }
-                None => break,
+                _ => break,
             }
         }
 


### PR DESCRIPTION
Closes #20.

Ports `Template` and `TemplateIterator` from fgbio (Scala) and fgpyo (Python). `Template` collects the primary R1/R2 alignments for a query name along with its supplementary and secondary records; `TemplateIterator` groups a queryname-sorted record stream into `Template`s.

## Process and background

I'm a software engineer learning bioinformatics through OSS tooling contributions; that's the motivation for this PR. The code was drafted with Claude (Opus 4.7). Before submitting I worked through the underlying SAM/BAM concepts in a teach-and-quiz loop with Claude until I could explain the abstraction in my own words. The diff was then cross-reviewed across fresh-context rounds by Claude and Gemini.

My own model, for calibration: `Template` groups alignment records by query name along two independent axes: R1/R2 (`FIRST_SEGMENT` / `LAST_SEGMENT`), and primary vs `SECONDARY` (`0x100`, multi-mapper alternates) vs `SUPPLEMENTARY` (`0x800`, split / chimeric alignment fragments). `TemplateIterator` is a streaming groupby on query name, assuming queryname-grouped input (`@HD SO:queryname` from upstream `samtools sort -n`).

## Source material being ported

Pinned to the upstream commits at the time this branch was written:

- fgbio `Template` case class + companion object: [`Bams.scala` lines 47-178 @ 768d38c0](https://github.com/fulcrumgenomics/fgbio/blob/768d38c02873e9dae27815dd94c0f6d556f87ac1/src/main/scala/com/fulcrumgenomics/bam/Bams.scala#L47-L178)
- fgbio `templateIterator`: [`ZipperBams.scala` line 109 @ 768d38c0](https://github.com/fulcrumgenomics/fgbio/blob/768d38c02873e9dae27815dd94c0f6d556f87ac1/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala#L109)
- fgpyo `Template`: [`fgpyo/sam/__init__.py` lines 1346-1563 @ 416f0f64](https://github.com/fulcrumgenomics/fgpyo/blob/416f0f64040a5ffc3f504afc1fb69d0d90552940/fgpyo/sam/__init__.py#L1346-L1563)
- fgpyo `TemplateIterator`: [`fgpyo/sam/__init__.py` lines 1564-1581 @ 416f0f64](https://github.com/fulcrumgenomics/fgpyo/blob/416f0f64040a5ffc3f504afc1fb69d0d90552940/fgpyo/sam/__init__.py#L1564-L1581)

## Semantics, matching fgbio

- Records flagged both secondary and supplementary go to secondary, per [@tfenne's comment](https://github.com/fulcrumgenomics/fgoxide/issues/20#issuecomment-2598690918) on the issue.
- Unpaired records and `SEGMENTED`-without-`FIRST`-or-`LAST` records follow fgbio's `!paired || firstOfPair` rule (R1 and R2 respectively).
- Mis-grouped input silently produces multiple `Template`s per name; the iterator only checks contiguity, by design (tracking seen names would defeat the streaming property). Documented in the module rustdoc.
- Empty input yields `None` from the iterator and `EmptyTemplate` from `Template::from_records`.

## API and cargo features

- `noodles-sam` and `bstr` are optional dependencies behind a default `sam` cargo feature; `cargo build --no-default-features` builds without them.
- `TemplateIterator` accepts `Iterator<Item = io::Result<RecordBuf>>` directly, matching what `noodles` readers produce.
- `Template::name` and the byte-typed `FgError` fields use `bstr::BString`, matching `RecordBuf::name`'s return type.
- `FgError::MultiplePrimaryAlignments::read` is a `WhichRead { R1, R2 }` enum.

## Out of scope (per the issue)

`fixMateInfo`, `unmapped`, `pairOrientation`, `allR1s`/`allR2s`. Happy to follow up.

## Possible follow-up: borrowed variant

A `Template<'a>` over the lazy `noodles::Record`, fed by a lending iterator, would let mmap'd or fully-buffered inputs skip per-record materialization. Sibling abstraction, not a replacement. Happy to open a separate issue.

## Open question

`Template` fields are `pub` to match fgbio's case-class surface. Direct mutation can break the constructor's per-template invariants; happy to switch to private + getters if you'd rather.
